### PR TITLE
Removing unused SDK caches to free up disk space

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       -
+        name: Remove Ruby, CodeQL, PyPy and Python folders
+        run: |
+          echo "Removing /opt/hostedtoolcache/Ruby, /opt/hostedtoolcache/CodeQL, /opt/hostedtoolcache/PyPy and /opt/hostedtoolcache/Python"
+          sudo rm -rf /opt/hostedtoolcache/Ruby || true
+          sudo rm -rf /opt/hostedtoolcache/CodeQL || true
+          sudo rm -rf /opt/hostedtoolcache/PyPy || true
+          sudo rm -rf /opt/hostedtoolcache/Python || true
+          echo "Cleanup complete."
+      -
         name: Checkout
         uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
       -


### PR DESCRIPTION
Removing unused SDK caches to free up disk space to address the "no space left on device issue"

<img width="1227" height="50" alt="image" src="https://github.com/user-attachments/assets/7ade619b-c09c-4498-869a-a429908a87df" />
