### PR TITLE
fix: Validate CAM connector for legacy resources

### DIFF
--- a/internal/trendmicro/cloud_account_management/azure/api/cam_connector.go
+++ b/internal/trendmicro/cloud_account_management/azure/api/cam_connector.go
@@ -73,7 +73,7 @@ func (c *CamClient) CreateSubscription(data *CreateSubscriptionRequest) error {
 
 	var resp *http.Response
 	var postRequestErr error
-	if describeResp != nil {
+	if describeResp != nil && describeResp.ApplicationID != "" {
 		// If the subscription already exists, we will modify it instead of creating a new one
 		fmt.Printf("Subscription already exists, modifying subscription: %s\n", data.SubscriptionID)
 		url := fmt.Sprintf("%s/beta/cam/azureSubscriptions/%s", c.Client.HostURL, data.SubscriptionID)


### PR DESCRIPTION
Validate CAM connector for legacy resources