### PR TITLE
impr: enhance cleanup step in release workflow to free up additional disk space

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,11 +22,14 @@ jobs:
       -
         name: Remove Ruby, CodeQL, PyPy and Python folders
         run: |
-          echo "Removing /opt/hostedtoolcache/Ruby, /opt/hostedtoolcache/CodeQL, /opt/hostedtoolcache/PyPy and /opt/hostedtoolcache/Python"
+          echo "Cleaning up disk space..."
+          echo "Removing /opt/hostedtoolcache/Ruby, /opt/hostedtoolcache/CodeQL, /opt/hostedtoolcache/PyPy, /opt/hostedtoolcache/Python, /usr/share/dotnet, and /usr/local/lib/android"
           sudo rm -rf /opt/hostedtoolcache/Ruby || true
           sudo rm -rf /opt/hostedtoolcache/CodeQL || true
           sudo rm -rf /opt/hostedtoolcache/PyPy || true
           sudo rm -rf /opt/hostedtoolcache/Python || true
+          sudo rm -rf /usr/share/dotnet || true
+          sudo rm -rf /usr/local/lib/android || true
           echo "Cleanup complete."
       -
         name: Checkout


### PR DESCRIPTION
To address this git action space issue
<img width="1437" height="114" alt="image" src="https://github.com/user-attachments/assets/3aca853a-c064-4be3-9c63-75eb743b0cae" />
