### PR TITLE
impr: enable replacement of existing artifacts during release process

### DIFF
--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -50,5 +50,6 @@ signs:
 release:
   # If you want to manually examine the release before its live, uncomment this line:
   # draft: true
+  replace_existing_artifacts: true
 changelog:
   skip: true


### PR DESCRIPTION
Trying to fix the issue: **422 Cannot upload assets to an immutable release.**
<img width="2124" height="418" alt="image" src="https://github.com/user-attachments/assets/2ce7c85a-0768-44ef-b893-be5cf9ab48eb" />

https://goreleaser.com/customization/release/?h=replace_existing_artifacts#github