### PR TITLE
impr: filter out the GCP non-billing projects

### DIFF
--- a/internal/trendmicro/cloud_account_management/gcp/resources/service_account_integration.go
+++ b/internal/trendmicro/cloud_account_management/gcp/resources/service_account_integration.go
@@ -1143,6 +1143,12 @@ func (r *ServiceAccountIntegration) discoverTargetProjects(
 							continue
 						}
 
+						// Filter out system-created projects (sys-*)
+						if IsSystemProject(project) {
+							tflog.Debug(ctx, fmt.Sprintf("[Service Account Key] Excluding system project: %s", project.ProjectId))
+							continue
+						}
+
 						// Filter out free trial projects if requested
 						if plan.ExcludeFreeTrialProjects.ValueBool() {
 							if IsFreeTrialProject(project) {
@@ -1181,6 +1187,12 @@ func (r *ServiceAccountIntegration) discoverTargetProjects(
 							continue
 						}
 
+						// Filter out system-created projects (sys-*)
+						if IsSystemProject(project) {
+							tflog.Debug(ctx, fmt.Sprintf("[Service Account Key] Excluding system project: %s", project.ProjectId))
+							continue
+						}
+
 						// Filter out free trial projects if requested
 						if plan.ExcludeFreeTrialProjects.ValueBool() {
 							if IsFreeTrialProject(project) {
@@ -1205,6 +1217,12 @@ func (r *ServiceAccountIntegration) discoverTargetProjects(
 				for _, project := range resp.Projects {
 					// Filter out non-active projects
 					if project.LifecycleState != config.LIFECYCLE_STATE_ACTIVE {
+						continue
+					}
+
+					// Filter out system-created projects (sys-*)
+					if IsSystemProject(project) {
+						tflog.Debug(ctx, fmt.Sprintf("[Service Account Key] Excluding system project: %s", project.ProjectId))
 						continue
 					}
 

--- a/internal/trendmicro/cloud_account_management/gcp/resources/utils.go
+++ b/internal/trendmicro/cloud_account_management/gcp/resources/utils.go
@@ -45,6 +45,17 @@ func ValidateDescription(description string) error {
 
 // ===== Project Utilities =====
 
+// IsSystemProject checks if a project is a GCP auto-created project that is not counted for billing.
+// Known patterns:
+//   - sys-*              : GCP system/infrastructure projects
+//   - apps-script-*      : Google Apps Script auto-created projects
+//   - google.com:*       : Legacy Google-owned cross-organization projects (e.g. google.com:api-project-*)
+func IsSystemProject(project *cloudresourcemanager.Project) bool {
+	return strings.HasPrefix(project.ProjectId, "sys-") ||
+		strings.HasPrefix(project.ProjectId, "apps-script-") ||
+		strings.HasPrefix(project.ProjectId, "google.com:")
+}
+
 // IsFreeTrialProject checks if a project is a free trial project.
 func IsFreeTrialProject(project *cloudresourcemanager.Project) bool {
 	// Check labels for free trial indicators


### PR DESCRIPTION
### Overview
Automatically excludes GCP auto-created system projects during project discovery in the CAM GCP Service Account Integration resource. These projects are not counted for billing and should not be onboarded.

### Changes
Added IsSystemProject() utility function in utils.go that identifies GCP system-created projects by matching known project ID prefixes:
- **sys-*** — GCP system/infrastructure projects
- **apps-script-*** — Google Apps Script auto-created projects
- **google.com:*** — Legacy Google-owned cross-organization projects (e.g., google.com:api-project-*)
Applied the filter in all 3 project discovery paths within service_account_integration.go (discoverTargetProjects), ensuring system projects are consistently excluded regardless of which code branch is taken. Skipped projects are logged at DEBUG level.


### Impact
Prevents non-billable system projects from being registered with Vision One, reducing noise and avoiding unnecessary API calls for projects that cannot be managed.
