### PR TITLE
feat: add prevent_destroy for cam azure connector

### DIFF
--- a/docs/resources/cam_connector_azure.md
+++ b/docs/resources/cam_connector_azure.md
@@ -223,6 +223,7 @@ resource "visionone_cam_connector_azure" "cam_connector_with_features_config" {
 - `features_config_file_path` (String) Path to the features configuration file
 - `is_shared_application` (Boolean) Whether the application is shared across multiple connectors
 - `management_group_details` (Attributes) Azure management group details for the connector (see [below for nested schema](#nestedatt--management_group_details))
+- `prevent_destroy` (Boolean) When `true` (default), Terraform destroy will not call the CAM DELETE API, preserving the subscription in CAM. Set to `false` to allow the subscription to be removed from CAM on destroy.
 
 ### Read-Only
 

--- a/internal/trendmicro/cloud_account_management/azure/resources/cam_connector.go
+++ b/internal/trendmicro/cloud_account_management/azure/resources/cam_connector.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -60,11 +61,12 @@ type CAMConnectorResourceModel struct {
 	State                     types.String                `tfsdk:"state"`
 	TenantID                  types.String                `tfsdk:"tenant_id"`
 	UpdatedDateTime           types.String                `tfsdk:"updated_date_time"`
-	ManagementGroupDetails    ManagementGroupDetailsModel `tfsdk:"management_group_details"`
+	ManagementGroupDetails    *ManagementGroupDetailsModel `tfsdk:"management_group_details"`
 	IsSharedApplication       types.Bool                  `tfsdk:"is_shared_application"`
 	CamDeployedRegion         types.String                `tfsdk:"cam_deployed_region"`
 	Features                  types.List                  `tfsdk:"features"`
 	FeaturesConfigFilePath    types.String                `tfsdk:"features_config_file_path"`
+	PreventDestroy            types.Bool                  `tfsdk:"prevent_destroy"`
 }
 
 type ManagementGroupDetailsModel struct {
@@ -227,6 +229,12 @@ func (r *CAMConnectorResource) Schema(ctx context.Context, req resource.SchemaRe
 				Optional:            true,
 				MarkdownDescription: "Path to the features configuration file",
 			},
+			"prevent_destroy": schema.BoolAttribute{
+				Optional:            true,
+				Computed:            true,
+				MarkdownDescription: "When `true` (default), Terraform destroy will not call the CAM DELETE API, preserving the subscription in CAM. Set to `false` to allow the subscription to be removed from CAM on destroy.",
+				Default:             booldefault.StaticBool(true),
+			},
 		},
 	}
 }
@@ -323,7 +331,7 @@ func (r *CAMConnectorResource) Create(ctx context.Context, req resource.CreateRe
 		plan.Name.ValueString(), plan.SubscriptionID.ValueString(), plan.TenantID.ValueString()))
 
 	// Convert management group details if provided
-	managementGroup, convertDiags := convertManagementGroupDetailsToAPI(ctx, &plan.ManagementGroupDetails)
+	managementGroup, convertDiags := convertManagementGroupDetailsToAPI(ctx, plan.ManagementGroupDetails)
 	resp.Diagnostics.Append(convertDiags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -404,18 +412,9 @@ func (r *CAMConnectorResource) Create(ctx context.Context, req resource.CreateRe
 			})
 		}
 
-		// Set features from API response only if plan did not specify any features.
-		// The API may return additional default features not present in the plan, which
-		// would cause "provider produced inconsistent result after apply" errors for
-		// Optional (non-Computed) attributes.
-		if plan.Features.IsNull() && len(res.Features) > 0 {
-			featuresList, featuresDiags := convertAPIFeaturesToTerraform(ctx, res.Features)
-			resp.Diagnostics.Append(featuresDiags...)
-			if resp.Diagnostics.HasError() {
-				return
-			}
-			plan.Features = featuresList
-		}
+		// Do not auto-populate features from API response when the user did not specify them.
+		// features has omitempty on the backend; keeping it null avoids sending stale or
+		// unsupported feature IDs on subsequent re-create operations in Read.
 		// Preserve FeaturesConfigFilePath from plan since API does not return it
 	}
 
@@ -463,7 +462,7 @@ func (r *CAMConnectorResource) Read(ctx context.Context, req resource.ReadReques
 		})
 
 		// Convert management group details if provided
-		managementGroup, convertDiags := convertManagementGroupDetailsToAPI(ctx, &state.ManagementGroupDetails)
+		managementGroup, convertDiags := convertManagementGroupDetailsToAPI(ctx, state.ManagementGroupDetails)
 		resp.Diagnostics.Append(convertDiags...)
 		if resp.Diagnostics.HasError() {
 			return
@@ -501,7 +500,7 @@ func (r *CAMConnectorResource) Read(ctx context.Context, req resource.ReadReques
 		}
 	} else {
 		// Convert management group details if provided
-		managementGroup, convertDiags := convertManagementGroupDetailsToAPI(ctx, &state.ManagementGroupDetails)
+		managementGroup, convertDiags := convertManagementGroupDetailsToAPI(ctx, state.ManagementGroupDetails)
 		resp.Diagnostics.Append(convertDiags...)
 		if resp.Diagnostics.HasError() {
 			return
@@ -604,17 +603,9 @@ func (r *CAMConnectorResource) Read(ctx context.Context, req resource.ReadReques
 			})
 		}
 
-		// Set features from API response only if state did not have explicit features.
-		// The API may return additional default features not in the original config, which
-		// would cause drift on subsequent plans for Optional (non-Computed) attributes.
-		if state.Features.IsNull() && len(res.Features) > 0 {
-			featuresList, featuresDiags := convertAPIFeaturesToTerraform(ctx, res.Features)
-			resp.Diagnostics.Append(featuresDiags...)
-			if resp.Diagnostics.HasError() {
-				return
-			}
-			state.Features = featuresList
-		}
+		// Do not auto-populate features from API response when the user did not specify them.
+		// features has omitempty on the backend; keeping it null avoids sending stale or
+		// unsupported feature IDs on subsequent re-create operations in Read.
 		// Preserve FeaturesConfigFilePath from state since API does not return it
 	}
 
@@ -689,7 +680,7 @@ func (r *CAMConnectorResource) Update(ctx context.Context, req resource.UpdateRe
 	}
 
 	// Convert management group details if provided
-	managementGroup, convertDiags := convertManagementGroupDetailsToAPI(ctx, &plan.ManagementGroupDetails)
+	managementGroup, convertDiags := convertManagementGroupDetailsToAPI(ctx, plan.ManagementGroupDetails)
 	resp.Diagnostics.Append(convertDiags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -772,21 +763,14 @@ func (r *CAMConnectorResource) Update(ctx context.Context, req resource.UpdateRe
 			})
 		}
 
-		// Use plan features if specified; otherwise fall back to API response features.
-		// The API may return additional default features not in the plan, which would
-		// cause drift on subsequent plans for Optional (non-Computed) attributes.
-		if !plan.Features.IsNull() {
-			state.Features = plan.Features
-		} else if len(res.Features) > 0 {
-			featuresList, featuresDiags := convertAPIFeaturesToTerraform(ctx, res.Features)
-			resp.Diagnostics.Append(featuresDiags...)
-			if resp.Diagnostics.HasError() {
-				return
-			}
-			state.Features = featuresList
-		}
+		// Use plan features (null when user did not specify them).
+		// Do not fall back to API response features: features has omitempty on the backend
+		// and auto-populating from API can persist unsupported feature IDs into state.
+		state.Features = plan.Features
 		// Preserve FeaturesConfigFilePath from plan since API does not return it
 		state.FeaturesConfigFilePath = plan.FeaturesConfigFilePath
+		// Preserve prevent_destroy from plan since API does not return it
+		state.PreventDestroy = plan.PreventDestroy
 	}
 
 	resp.State.Set(ctx, &state)
@@ -798,6 +782,11 @@ func (r *CAMConnectorResource) Delete(ctx context.Context, req resource.DeleteRe
 	diags := req.State.Get(ctx, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if state.PreventDestroy.IsNull() || state.PreventDestroy.IsUnknown() || state.PreventDestroy.ValueBool() {
+		tflog.Info(ctx, fmt.Sprintf("[CAM Connector][Delete] prevent_destroy=true (or unset), skipping CAM DELETE for subscription %s", state.SubscriptionID.ValueString()))
 		return
 	}
 
@@ -814,6 +803,10 @@ func (r *CAMConnectorResource) Delete(ctx context.Context, req resource.DeleteRe
 func convertManagementGroupDetailsToAPI(ctx context.Context, mgmtGroup *ManagementGroupDetailsModel) (api.ManagementGroupDetails, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	var managementGroup api.ManagementGroupDetails
+
+	if mgmtGroup == nil {
+		return managementGroup, diags
+	}
 
 	if !mgmtGroup.ID.IsNull() {
 		var excludedSubsStr string
@@ -870,43 +863,6 @@ func extractFeatures(ctx context.Context, featuresList types.List) ([]api.Featur
 	return features, diags
 }
 
-func convertAPIFeaturesToTerraform(ctx context.Context, apiFeatures []api.Feature) (types.List, diag.Diagnostics) {
-	var diags diag.Diagnostics
-
-	objectType := types.ObjectType{
-		AttrTypes: map[string]attr.Type{
-			"id":      types.StringType,
-			"regions": types.ListType{ElemType: types.StringType},
-		},
-	}
-
-	if len(apiFeatures) == 0 {
-		emptyList, listDiags := types.ListValue(objectType, []attr.Value{})
-		diags.Append(listDiags...)
-		return emptyList, diags
-	}
-
-	var featureModels []AzureFeatureModel
-	for _, apiFeature := range apiFeatures {
-		regions := apiFeature.Regions
-		if regions == nil {
-			regions = []string{}
-		}
-		regionsList, regionDiags := types.ListValueFrom(ctx, types.StringType, regions)
-		diags.Append(regionDiags...)
-		if diags.HasError() {
-			return types.List{}, diags
-		}
-		featureModels = append(featureModels, AzureFeatureModel{
-			ID:      types.StringValue(apiFeature.ID),
-			Regions: regionsList,
-		})
-	}
-
-	resultList, listDiags := types.ListValueFrom(ctx, objectType, featureModels)
-	diags.Append(listDiags...)
-	return resultList, diags
-}
 
 func convertAPISecurityServicesToTerraform(ctx context.Context, apiServices []cam.ConnectedSecurityService) (types.List, diag.Diagnostics) {
 	var diags diag.Diagnostics


### PR DESCRIPTION
* Add `prevent_destroy` (Boolean) When `true` (default), Terraform destroy will not call the CAM DELETE API, preserving the subscription in CAM. Set to `false` to allow the subscription to be removed from CAM on destroy.