### PR TITLE
refactor: cam service principal tags and connector enhancement

### DIFF
--- a/internal/trendmicro/cloud_account_management/azure/resources/cam_connector.go
+++ b/internal/trendmicro/cloud_account_management/azure/resources/cam_connector.go
@@ -155,9 +155,6 @@ func (r *CAMConnectorResource) Schema(ctx context.Context, req resource.SchemaRe
 			"state": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "Current state of the connector",
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
 			},
 			"tenant_id": schema.StringAttribute{
 				Required:            true,

--- a/internal/trendmicro/cloud_account_management/azure/resources/service_principal.go
+++ b/internal/trendmicro/cloud_account_management/azure/resources/service_principal.go
@@ -237,12 +237,11 @@ func (r *servicePrincipal) Update(ctx context.Context, req resource.UpdateReques
 	}
 
 	displayName := getDisplayName(plan.DisplayName, subscriptionID)
-	var tags []string
+	tags := plan.Tags
 	if len(tags) == 0 {
 		tags = state.Tags
 	} else {
 		tflog.Info(ctx, fmt.Sprintf("[Service Principal] Using provided barebone version: %s", plan.Tags[0]))
-		tags = plan.Tags
 	}
 	app := models.NewApplication()
 	app.SetDisplayName(&displayName)
@@ -254,11 +253,12 @@ func (r *servicePrincipal) Update(ctx context.Context, req resource.UpdateReques
 		return
 	}
 
-	state.ClientID = types.StringValue(*app.GetAppId())
+	state.ClientID = types.StringValue(state.ClientID.ValueString())
 	state.DisplayName = types.StringValue(displayName)
-	state.ObjectID = types.StringValue(*app.GetId())
+	state.ObjectID = types.StringValue(state.ObjectID.ValueString())
 	state.PrincipalID = types.StringValue(state.PrincipalID.ValueString())
 	state.SubscriptionID = plan.SubscriptionID
+	state.Tags = tags
 
 	diags = resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)


### PR DESCRIPTION
This PR fixes two bugs in the Azure CAM resources.

Service Principal — tag update fix

Previously, when updating a service principal, the tags field was not being applied correctly. The variable was declared empty before the conditional check, so updates that provided new tags were ignored. This fix initializes tags from the plan upfront so tag changes are correctly picked up.

Additionally, after an update, client_id and object_id were being overwritten with values from the API response, which could cause unexpected diffs on subsequent plans. They are now preserved from the existing state.

CAM Connector — state attribute

Removed the UseStateForUnknown plan modifier from the state attribute. This attribute reflects the live connector state and should always be refreshed from the API rather than carried over from prior state.