### PR TITLE
refactor: add excludeCloudAssets to azure connector

### DIFF
--- a/internal/trendmicro/cloud_account_management/azure/api/cam_connector.go
+++ b/internal/trendmicro/cloud_account_management/azure/api/cam_connector.go
@@ -86,7 +86,7 @@ func (c *CamClient) CreateSubscription(data *CreateSubscriptionRequest) error {
 	fmt.Printf("Preparing to create subscription with data: %s\n", string(jsonData))
 
 	// Attempt to read the subscription to determine if it already exists
-	describeResp, err := c.ReadSubscription(data.SubscriptionID)
+	describeResp, err := c.ReadSubscription(data.SubscriptionID, true)
 	if err != nil {
 		if !strings.Contains(err.Error(), `"code": "NotFound"`) {
 			return fmt.Errorf("failed to verify subscription existence: %w", err)
@@ -154,9 +154,12 @@ func (c *CamClient) CreateSubscription(data *CreateSubscriptionRequest) error {
 	return nil
 }
 
-func (c *CamClient) ReadSubscription(subscriptionID string) (*SubscriptionResponse, error) {
+func (c *CamClient) ReadSubscription(subscriptionID string, excludeCloudAssets bool) (*SubscriptionResponse, error) {
 	cam.JitterSleep(cam.AzureJitterConfig)
 	url := fmt.Sprintf("%s/beta/cam/azureSubscriptions/%s", c.Client.HostURL, subscriptionID)
+	if excludeCloudAssets {
+		url += "?excludeCloudAssets=true"
+	}
 
 	req, err := http.NewRequest("GET", url, http.NoBody)
 	if err != nil {

--- a/internal/trendmicro/cloud_account_management/azure/resources/cam_connector.go
+++ b/internal/trendmicro/cloud_account_management/azure/resources/cam_connector.go
@@ -364,7 +364,7 @@ func (r *CAMConnectorResource) Create(ctx context.Context, req resource.CreateRe
 		)
 		return
 	}
-	res, err := r.client.ReadSubscription(plan.SubscriptionID.ValueString())
+	res, err := r.client.ReadSubscription(plan.SubscriptionID.ValueString(), true)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"[CAM Connector][Create] Error Describing Subscription",
@@ -452,7 +452,7 @@ func (r *CAMConnectorResource) Read(ctx context.Context, req resource.ReadReques
 		}
 	}
 
-	res, err := r.client.ReadSubscription(state.SubscriptionID.ValueString())
+	res, err := r.client.ReadSubscription(state.SubscriptionID.ValueString(), true)
 	if err != nil {
 		tflog.Warn(ctx, "[CAM Connector][Read] Failed to describe subscription, will attempt to create it", map[string]any{
 			"error": err.Error(),
@@ -549,7 +549,7 @@ func (r *CAMConnectorResource) Read(ctx context.Context, req resource.ReadReques
 		}
 	}
 
-	res, err = r.client.ReadSubscription(state.SubscriptionID.ValueString())
+	res, err = r.client.ReadSubscription(state.SubscriptionID.ValueString(), true)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"[CAM Connector][Read] Error Describing Subscription",
@@ -714,7 +714,7 @@ func (r *CAMConnectorResource) Update(ctx context.Context, req resource.UpdateRe
 		return
 	}
 
-	res, err := r.client.ReadSubscription(plan.SubscriptionID.ValueString())
+	res, err := r.client.ReadSubscription(plan.SubscriptionID.ValueString(), true)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"[CAM Connector][Update] Error Describing Subscription",


### PR DESCRIPTION
## Summary and Motivation

Updated the Azure CAM connector to exclude cloud asset data from subscription read responses by appending `?excludeCloudAssets=true` to the internal subscription API call. Previously, every Terraform create, read, and update operation on an `visionone_cam_connector` resource fetched the full cloud asset payload, which was unnecessary for connector state management. This refactor reduces response payload size and improves the performance and reliability of Azure connector operations for users managing large subscriptions.

