### PR TITLE
feat: add cam azure connector support auto-discovery

### DIFF
--- a/docs/resources/cam_connector_azure.md
+++ b/docs/resources/cam_connector_azure.md
@@ -37,6 +37,8 @@ resource "visionone_cam_connector_azure" "cam_connector_with_mgmt_group" {
   is_shared_application     = true
   cam_deployed_region       = "us-east-1"
 
+  auto_discovery_enabled = false
+
   management_group_details = {
     id           = "mg-production"
     display_name = "Production Management Group"
@@ -216,6 +218,7 @@ resource "visionone_cam_connector_azure" "cam_connector_with_features_config" {
 
 ### Optional
 
+- `auto_discovery_enabled` (Boolean) Whether the auto-subscription-discovery Terraform template variant has been applied for this management group. Set by the CAM template generator; defaults to `false`. Only read on the primary subscription.
 - `cam_deployed_region` (String) Region where CAM is deployed for this connector
 - `connected_security_services` (Attributes List) List of connected security services for the connector (see [below for nested schema](#nestedatt--connected_security_services))
 - `description` (String) Description of the connector

--- a/internal/trendmicro/cloud_account_management/azure/api/cam_connector.go
+++ b/internal/trendmicro/cloud_account_management/azure/api/cam_connector.go
@@ -26,6 +26,7 @@ type CreateSubscriptionRequest struct {
 	IsTFProviderDeployed      bool                           `json:"isTFProviderDeployed"`
 	Features                  *[]Feature                     `json:"features,omitempty"`
 	FeaturesConfigFilePath    string                         `json:"featuresConfigFilePath,omitempty"`
+	AutoDiscoveryEnabled      bool                           `json:"autoDiscoveryEnabled"`
 }
 
 type ModifySubscriptionRequest struct {
@@ -42,6 +43,7 @@ type ModifySubscriptionRequest struct {
 	IsTFProviderDeployed      bool                           `json:"isTFProviderDeployed"`
 	Features                  *[]Feature                     `json:"features,omitempty"`
 	FeaturesConfigFilePath    string                         `json:"featuresConfigFilePath,omitempty"`
+	AutoDiscoveryEnabled      bool                           `json:"autoDiscoveryEnabled"`
 }
 
 type SubscriptionResponse struct {

--- a/internal/trendmicro/cloud_account_management/azure/resources/cam_connector.go
+++ b/internal/trendmicro/cloud_account_management/azure/resources/cam_connector.go
@@ -67,6 +67,7 @@ type CAMConnectorResourceModel struct {
 	Features                  types.List                  `tfsdk:"features"`
 	FeaturesConfigFilePath    types.String                `tfsdk:"features_config_file_path"`
 	PreventDestroy            types.Bool                  `tfsdk:"prevent_destroy"`
+	AutoDiscoveryEnabled      types.Bool                  `tfsdk:"auto_discovery_enabled"`
 }
 
 type ManagementGroupDetailsModel struct {
@@ -232,6 +233,12 @@ func (r *CAMConnectorResource) Schema(ctx context.Context, req resource.SchemaRe
 				MarkdownDescription: "When `true` (default), Terraform destroy will not call the CAM DELETE API, preserving the subscription in CAM. Set to `false` to allow the subscription to be removed from CAM on destroy.",
 				Default:             booldefault.StaticBool(true),
 			},
+			"auto_discovery_enabled": schema.BoolAttribute{
+				Optional:            true,
+				Computed:            true,
+				MarkdownDescription: "Whether the auto-subscription-discovery Terraform template variant has been applied for this management group. Set by the CAM template generator; defaults to `false`. Only read on the primary subscription.",
+				Default:             booldefault.StaticBool(false),
+			},
 		},
 	}
 }
@@ -354,6 +361,7 @@ func (r *CAMConnectorResource) Create(ctx context.Context, req resource.CreateRe
 		IsTFProviderDeployed:      true,
 		Features:                  features,
 		FeaturesConfigFilePath:    plan.FeaturesConfigFilePath.ValueString(),
+		AutoDiscoveryEnabled:      plan.AutoDiscoveryEnabled.ValueBool(),
 	}
 
 	createErr := r.client.CreateSubscription(body)
@@ -485,6 +493,7 @@ func (r *CAMConnectorResource) Read(ctx context.Context, req resource.ReadReques
 			IsTFProviderDeployed:      true,
 			Features:                  stateFeatures,
 			FeaturesConfigFilePath:    state.FeaturesConfigFilePath.ValueString(),
+			AutoDiscoveryEnabled:      state.AutoDiscoveryEnabled.ValueBool(),
 		}
 
 		err = r.client.CreateSubscription(body)
@@ -529,6 +538,7 @@ func (r *CAMConnectorResource) Read(ctx context.Context, req resource.ReadReques
 			IsTFProviderDeployed:      true,
 			Features:                  stateFeatures,
 			FeaturesConfigFilePath:    state.FeaturesConfigFilePath.ValueString(),
+			AutoDiscoveryEnabled:      state.AutoDiscoveryEnabled.ValueBool(),
 		}
 
 		err = r.client.UpdateSubscription(res.SubscriptionID, body)
@@ -703,6 +713,7 @@ func (r *CAMConnectorResource) Update(ctx context.Context, req resource.UpdateRe
 		IsTFProviderDeployed:      true,
 		Features:                  features,
 		FeaturesConfigFilePath:    plan.FeaturesConfigFilePath.ValueString(),
+		AutoDiscoveryEnabled:      plan.AutoDiscoveryEnabled.ValueBool(),
 	}
 
 	err := r.client.UpdateSubscription(subscriptionID, body)
@@ -768,6 +779,7 @@ func (r *CAMConnectorResource) Update(ctx context.Context, req resource.UpdateRe
 		state.FeaturesConfigFilePath = plan.FeaturesConfigFilePath
 		// Preserve prevent_destroy from plan since API does not return it
 		state.PreventDestroy = plan.PreventDestroy
+		state.AutoDiscoveryEnabled = plan.AutoDiscoveryEnabled
 	}
 
 	resp.State.Set(ctx, &state)


### PR DESCRIPTION
## Summary

Adds a new optional `auto_discovery_enabled` boolean attribute to the `visionone_cam_connector_azure` resource. The flag indicates whether the auto-subscription-discovery Terraform template variant has been applied for the management group and is forwarded to the Vision One CAM API on create, read-reconciliation, and update.
