### PR TITLE
refactor: cam azure registration retry enhancement

### DIFF
--- a/internal/trendmicro/cloud_account_management/azure/resources/federated_identity.go
+++ b/internal/trendmicro/cloud_account_management/azure/resources/federated_identity.go
@@ -176,7 +176,11 @@ func (r *federatedIdentity) Create(ctx context.Context, req resource.CreateReque
 	fed.SetIssuer(toStringPointer(issuerURL))
 	fed.SetSubject(toStringPointer(`urn:visionone:identity:` + visionOneRegionCode + `:` + v1BusinessID + `:account/` + v1BusinessID))
 
-	_, err = client.GraphClient.Applications().ByApplicationId(*objectId).FederatedIdentityCredentials().Post(ctx, fed, nil)
+	// Retry while the just-created app registration is still propagating.
+	err = retryOnGraphPropagation(ctx, "Federated Identity", func() error {
+		_, e := client.GraphClient.Applications().ByApplicationId(*objectId).FederatedIdentityCredentials().Post(ctx, fed, nil)
+		return e
+	})
 	if err != nil {
 		resp.Diagnostics.AddError("[Federated Identity][Create] Failed to create federated identity credential", err.Error())
 		return

--- a/internal/trendmicro/cloud_account_management/azure/resources/retry.go
+++ b/internal/trendmicro/cloud_account_management/azure/resources/retry.go
@@ -1,0 +1,58 @@
+package azure
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+// Microsoft Graph error fragments meaning a freshly created app object has not
+// yet replicated across directory replicas.
+var graphPropagationErrorSubstrings = []string{
+	"does not reference a valid application object",
+	"does not exist or one of its queried reference-property objects are not present",
+}
+
+func isGraphPropagationError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	for _, s := range graphPropagationErrorSubstrings {
+		if strings.Contains(msg, s) {
+			return true
+		}
+	}
+	return false
+}
+
+// retryOnGraphPropagation retries fn on Graph propagation errors with capped
+// exponential backoff (5s,10s,20s,30s,30s,30s). Other errors return immediately.
+func retryOnGraphPropagation(ctx context.Context, label string, fn func() error) error {
+	const maxRetries = 6
+	baseDelay := 5 * time.Second
+	maxDelay := 30 * time.Second
+
+	var err error
+	for attempt := 0; attempt <= maxRetries; attempt++ {
+		err = fn()
+		if err == nil || !isGraphPropagationError(err) {
+			return err
+		}
+		if attempt == maxRetries {
+			break
+		}
+		delay := min(baseDelay*time.Duration(1<<attempt), maxDelay)
+		tflog.Info(ctx, fmt.Sprintf("[%s] app registration not yet propagated, retrying in %s (attempt %d/%d): %s",
+			label, delay, attempt+1, maxRetries, err.Error()))
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(delay):
+		}
+	}
+	return err
+}

--- a/internal/trendmicro/cloud_account_management/azure/resources/service_principal.go
+++ b/internal/trendmicro/cloud_account_management/azure/resources/service_principal.go
@@ -386,7 +386,13 @@ func (r *servicePrincipal) createServicePrincipal(ctx context.Context, client *m
 	// the barebone `Version:...` tag and any `<feature-id>=<version>` feature tags.
 	sp.SetTags(tags)
 
-	createdSp, err := client.ServicePrincipals().Post(ctx, sp, nil)
+	// Retry while the just-created app registration is still propagating.
+	var createdSp models.ServicePrincipalable
+	err = retryOnGraphPropagation(ctx, "Service Principal", func() error {
+		var e error
+		createdSp, e = client.ServicePrincipals().Post(ctx, sp, nil)
+		return e
+	})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### Fixed

- **Azure connector provisioning reliability.** Resolved intermittent failures when
  connecting a new Azure subscription where setup would error out with messages like
  "does not reference a valid application object." The provider now automatically
  waits and retries while a newly created Azure app registration finishes propagating
  across Microsoft Entra ID (Azure AD), so creating the federated identity credential
  and service principal succeeds without manual re-runs.